### PR TITLE
Config paths

### DIFF
--- a/cmd/ssh-tunnel/main.go
+++ b/cmd/ssh-tunnel/main.go
@@ -14,7 +14,7 @@ import (
 )
 
 var (
-	configfile  = flag.String("config", "ssh-tunnel.hcl", "The config file to use")
+	configfile  = flag.String("config", "", "The config file to use")
 	flagNoColor = flag.Bool("no-color", false, "Disable color output")
 	v           = flag.Bool("version", false, "Print the version and exit")
 	newconfig   = flag.Bool("init", false, "Create a new config file")
@@ -37,11 +37,23 @@ func main() {
 		return
 	}
 
-	run()
+	if err := run(); err != nil {
+		fmt.Println("ERROR:", err)
+	}
 }
 
-func run() {
-	config := config.Parse(*configfile)
+func run() (err error) {
+	var path_to_config string
+	if *configfile == "" {
+		path_to_config, err = config.FindConfig()
+		if err != nil {
+			return err
+		}
+	} else {
+		path_to_config = *configfile
+	}
+
+	config := config.Parse(path_to_config)
 
 	var wg sync.WaitGroup
 	for _, c := range config {
@@ -57,6 +69,7 @@ func run() {
 	}
 
 	wg.Wait()
+	return nil
 }
 
 func PrintVersion() {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -32,11 +32,6 @@ type Remote struct {
 	Host string `hcl:"host"`
 }
 
-// String prints out a pretty version of the tunnel struct
-func (t Tunnel) String() {
-
-}
-
 func Parse(configfile string) []Tunnel {
 	parser := hclparse.NewParser()
 	file, diags := parser.ParseHCLFile(configfile)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,9 +1,11 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"os"
+	"path/filepath"
 	"text/tabwriter"
 
 	"github.com/fatih/color"
@@ -71,4 +73,33 @@ func printConfig(config []Tunnel) {
 		fmt.Fprintf(w, "%s@%s\t%s\t->\t%s\n", tunnel.User, tunnel.Remote.Host, from, to)
 	}
 	w.Flush()
+}
+
+func FindConfig() (string, error) {
+	homedir, _ := os.UserHomeDir()
+	currentDir := cwd()
+	searchPaths := []string{
+		currentDir + "/ssh-tunnel.hcl",
+		homedir + "/.config/ssh-tunnel/ssh-tunnel.hcl",
+		"/etc/ssh-tunnel/ssh-tunnel.hcl",
+	}
+
+	for _, spath := range searchPaths {
+		fmt.Println(spath)
+		if _, err := os.Stat(spath); err == nil {
+			fmt.Println("Found config in", spath)
+			return spath, nil
+		}
+	}
+
+	return "", errors.New("no ssh-tunnel.hcl found")
+}
+
+func cwd() string {
+	ex, err := filepath.Abs("./")
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(ex)
+	return ex
 }

--- a/internal/template/template.go
+++ b/internal/template/template.go
@@ -14,7 +14,7 @@ func Write() {
 	if !exists() {
 		os.WriteFile(filename, []byte(template()), perms)
 	} else {
-		log.Println("a ssh-tunnel-hcl file already exists, nothing to do")
+		log.Println("a ssh-tunnel.hcl file already exists, nothing to do")
 	}
 }
 


### PR DESCRIPTION
If no config is provided with `-config` flag; look for a config in order of

1. current working directory, if not found then
2. `~/.config/ssh-tunnel/ssh-tunnel.hcl`, if not found then
3. `/etc/ssh-tunnel/ssh-tunnel.hcl`, if not found then
4. exit with message